### PR TITLE
Implement community backend skeleton with authentication, boards and notifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,23 +20,24 @@ configurations {
 	}
 }
 
-repositories {
-	mavenCentral()
-}
+  repositories {
+          mavenCentral()
+  }
 
-dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
+  dependencies {
+          implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+          implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+          implementation 'org.springframework.boot:spring-boot-starter-security'
+          implementation 'org.springframework.boot:spring-boot-starter-validation'
+          implementation 'org.springframework.boot:spring-boot-starter-web'
+          compileOnly 'org.projectlombok:lombok'
+          runtimeOnly 'org.postgresql:postgresql'
+          runtimeOnly 'com.h2database:h2' // in-memory database used for tests and local development
+          annotationProcessor 'org.projectlombok:lombok'
+          testImplementation 'org.springframework.boot:spring-boot-starter-test'
+          testImplementation 'org.springframework.security:spring-security-test'
+          testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+  }
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/moe/overnight/webstudy/config/SecurityConfig.java
+++ b/src/main/java/moe/overnight/webstudy/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package moe.overnight.webstudy.config;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.service.UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Basic security configuration enabling form login and Google OAuth2 login.
+ * The configuration demonstrates how {@link HttpSecurity} is used to build the
+ * filter chain that secures HTTP endpoints.
+ */
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final UserService userService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // HttpSecurity uses the builder pattern to configure many security aspects.
+        http
+            .csrf(csrf -> csrf.disable()) // Disabled for simplicity; not recommended for production.
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/auth/**", "/oauth2/**").permitAll()
+                    .anyRequest().authenticated())
+            .formLogin(login -> login.permitAll())
+            .oauth2Login(oauth2 -> oauth2) // Google OAuth2 uses settings from application.properties
+            .userDetailsService(userService);
+        return http.build();
+    }
+
+    /**
+     * Password encoder bean used by Spring Security to hash passwords. BCrypt is
+     * the de-facto standard for password hashing in Spring applications.
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/controller/AuthController.java
+++ b/src/main/java/moe/overnight/webstudy/controller/AuthController.java
@@ -1,0 +1,38 @@
+package moe.overnight.webstudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.service.UserService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+/**
+ * Authentication related endpoints such as registration and profile lookup.
+ */
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final UserService userService;
+
+    /**
+     * Registers a new user using form parameters. In a production system a DTO
+     * and validation would be used instead.
+     */
+    @PostMapping("/register")
+    public User register(@RequestParam String username,
+                         @RequestParam String password,
+                         @RequestParam String email) {
+        return userService.register(username, password, email);
+    }
+
+    /**
+     * Returns profile information of the authenticated user.
+     */
+    @GetMapping("/me")
+    public Optional<User> me(@AuthenticationPrincipal User user) {
+        return userService.findById(user.getId());
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/controller/CommentController.java
+++ b/src/main/java/moe/overnight/webstudy/controller/CommentController.java
@@ -1,0 +1,33 @@
+package moe.overnight.webstudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.comment.Comment;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.service.CommentService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Endpoints for creating and viewing comments.
+ */
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping
+    public Comment add(@PathVariable Long postId,
+                       @RequestParam String content,
+                       @RequestParam(required = false) Long parentId,
+                       @AuthenticationPrincipal User user) {
+        return commentService.addComment(postId, parentId, content, user);
+    }
+
+    @GetMapping
+    public List<Comment> list(@PathVariable Long postId) {
+        return commentService.listByPost(postId);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/controller/NotificationController.java
+++ b/src/main/java/moe/overnight/webstudy/controller/NotificationController.java
@@ -1,0 +1,30 @@
+package moe.overnight.webstudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.notification.Notification;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.service.NotificationService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Notification retrieval and update endpoints.
+ */
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public List<Notification> list(@AuthenticationPrincipal User user) {
+        return notificationService.list(user);
+    }
+
+    @PostMapping("/{id}/read")
+    public void markRead(@PathVariable Long id) {
+        notificationService.markRead(id);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/controller/PostController.java
+++ b/src/main/java/moe/overnight/webstudy/controller/PostController.java
@@ -1,0 +1,33 @@
+package moe.overnight.webstudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.post.Post;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.service.PostService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * REST endpoints for managing posts.
+ */
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping
+    public Post create(@RequestParam String title,
+                       @RequestParam String content,
+                       @RequestParam Long categoryId,
+                       @AuthenticationPrincipal User user) {
+        return postService.createPost(title, content, categoryId, user);
+    }
+
+    @GetMapping("/category/{categoryId}")
+    public List<Post> list(@PathVariable Long categoryId) {
+        return postService.listByCategory(categoryId);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/controller/SubscriptionController.java
+++ b/src/main/java/moe/overnight/webstudy/controller/SubscriptionController.java
@@ -1,0 +1,25 @@
+package moe.overnight.webstudy.controller;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.subscription.Subscription;
+import moe.overnight.webstudy.domain.subscription.SubscriptionPlan;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.service.SubscriptionService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller handling subscription endpoints.
+ */
+@RestController
+@RequestMapping("/subscription")
+@RequiredArgsConstructor
+public class SubscriptionController {
+    private final SubscriptionService subscriptionService;
+
+    @PostMapping
+    public Subscription subscribe(@RequestParam SubscriptionPlan plan,
+                                  @AuthenticationPrincipal User user) {
+        return subscriptionService.subscribe(user, plan);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/domain/category/Category.java
+++ b/src/main/java/moe/overnight/webstudy/domain/category/Category.java
@@ -1,0 +1,24 @@
+package moe.overnight.webstudy.domain.category;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * Represents a discussion board category. Posts are grouped by categories
+ * to provide a better user experience.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Human readable category name. */
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/src/main/java/moe/overnight/webstudy/domain/comment/Comment.java
+++ b/src/main/java/moe/overnight/webstudy/domain/comment/Comment.java
@@ -1,0 +1,43 @@
+package moe.overnight.webstudy.domain.comment;
+
+import jakarta.persistence.*;
+import lombok.*;
+import moe.overnight.webstudy.domain.post.Post;
+import moe.overnight.webstudy.domain.user.User;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Comment entity supporting nested replies through a self-referencing
+ * parent-child relationship.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Post post;
+
+    @ManyToOne(optional = false)
+    private User author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>();
+
+    @Lob
+    private String content;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/moe/overnight/webstudy/domain/notification/Notification.java
+++ b/src/main/java/moe/overnight/webstudy/domain/notification/Notification.java
@@ -1,0 +1,31 @@
+package moe.overnight.webstudy.domain.notification;
+
+import jakarta.persistence.*;
+import lombok.*;
+import moe.overnight.webstudy.domain.user.User;
+
+import java.time.LocalDateTime;
+
+/**
+ * Simple notification entity storing a message for a user.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    private String message;
+
+    private boolean read;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/moe/overnight/webstudy/domain/post/Post.java
+++ b/src/main/java/moe/overnight/webstudy/domain/post/Post.java
@@ -1,0 +1,38 @@
+package moe.overnight.webstudy.domain.post;
+
+import jakarta.persistence.*;
+import lombok.*;
+import moe.overnight.webstudy.domain.category.Category;
+import moe.overnight.webstudy.domain.user.User;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing a board post. Each post belongs to a {@link Category}
+ * and has an author {@link User}.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    private String content;
+
+    @ManyToOne(optional = false)
+    private User author;
+
+    @ManyToOne(optional = false)
+    private Category category;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/moe/overnight/webstudy/domain/subscription/Subscription.java
+++ b/src/main/java/moe/overnight/webstudy/domain/subscription/Subscription.java
@@ -1,0 +1,32 @@
+package moe.overnight.webstudy.domain.subscription;
+
+import jakarta.persistence.*;
+import lombok.*;
+import moe.overnight.webstudy.domain.user.User;
+
+import java.time.LocalDate;
+
+/**
+ * Represents a user's monthly subscription.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Subscription {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private SubscriptionPlan plan;
+
+    private LocalDate startDate;
+
+    private boolean active;
+}

--- a/src/main/java/moe/overnight/webstudy/domain/subscription/SubscriptionPlan.java
+++ b/src/main/java/moe/overnight/webstudy/domain/subscription/SubscriptionPlan.java
@@ -1,0 +1,11 @@
+package moe.overnight.webstudy.domain.subscription;
+
+/**
+ * Available subscription plans for the service. Pricing or feature details
+ * would typically be stored elsewhere; here we only model plan identity.
+ */
+public enum SubscriptionPlan {
+    BASIC,
+    STANDARD,
+    PRO
+}

--- a/src/main/java/moe/overnight/webstudy/domain/user/User.java
+++ b/src/main/java/moe/overnight/webstudy/domain/user/User.java
@@ -1,0 +1,82 @@
+package moe.overnight.webstudy.domain.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * JPA entity representing users of the system.
+ * <p>
+ * The class implements {@link UserDetails} so that instances can be used
+ * directly by Spring Security's authentication infrastructure.
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User implements UserDetails {
+
+    /** Unique surrogate key for the user. */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Login identifier used for form based authentication. */
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    /** Bcrypt encoded password. */
+    @Column(nullable = false)
+    private String password;
+
+    /** User's e-mail address for contact and OAuth2 mapping. */
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    /** Display name and short bio for profile functionality. */
+    private String displayName;
+    private String bio;
+
+    /** Role of the user. */
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    // --- UserDetails implementation ---
+
+    /**
+     * Returns authorities granted to the user. Spring Security expects a collection
+     * of {@link GrantedAuthority} instances representing roles or permissions.
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true; // account expiration is not tracked in this sample
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true; // account locking not implemented for brevity
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true; // credentials expiration not tracked
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true; // all users are enabled by default
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/domain/user/UserRole.java
+++ b/src/main/java/moe/overnight/webstudy/domain/user/UserRole.java
@@ -1,0 +1,10 @@
+package moe.overnight.webstudy.domain.user;
+
+/**
+ * Enumeration of roles for application users. Using an enum makes it easy
+ * to provide type safety and integrate with Spring Security's authority model.
+ */
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/moe/overnight/webstudy/repository/CategoryRepository.java
+++ b/src/main/java/moe/overnight/webstudy/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package moe.overnight.webstudy.repository;
+
+import moe.overnight.webstudy.domain.category.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for managing {@link Category} entities.
+ */
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/moe/overnight/webstudy/repository/CommentRepository.java
+++ b/src/main/java/moe/overnight/webstudy/repository/CommentRepository.java
@@ -1,0 +1,17 @@
+package moe.overnight.webstudy.repository;
+
+import moe.overnight.webstudy.domain.comment.Comment;
+import moe.overnight.webstudy.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repository for {@link Comment} entities.
+ */
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    /**
+     * Returns all comments belonging to the given post.
+     */
+    List<Comment> findByPost(Post post);
+}

--- a/src/main/java/moe/overnight/webstudy/repository/NotificationRepository.java
+++ b/src/main/java/moe/overnight/webstudy/repository/NotificationRepository.java
@@ -1,0 +1,17 @@
+package moe.overnight.webstudy.repository;
+
+import moe.overnight.webstudy.domain.notification.Notification;
+import moe.overnight.webstudy.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repository providing data access for {@link Notification} entities.
+ */
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    /**
+     * Finds all notifications for a specific user.
+     */
+    List<Notification> findByUser(User user);
+}

--- a/src/main/java/moe/overnight/webstudy/repository/PostRepository.java
+++ b/src/main/java/moe/overnight/webstudy/repository/PostRepository.java
@@ -1,0 +1,17 @@
+package moe.overnight.webstudy.repository;
+
+import moe.overnight.webstudy.domain.category.Category;
+import moe.overnight.webstudy.domain.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repository exposing persistence operations for {@link Post} entities.
+ */
+public interface PostRepository extends JpaRepository<Post, Long> {
+    /**
+     * Finds all posts within a particular {@link Category}.
+     */
+    List<Post> findByCategory(Category category);
+}

--- a/src/main/java/moe/overnight/webstudy/repository/SubscriptionRepository.java
+++ b/src/main/java/moe/overnight/webstudy/repository/SubscriptionRepository.java
@@ -1,0 +1,10 @@
+package moe.overnight.webstudy.repository;
+
+import moe.overnight.webstudy.domain.subscription.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for handling {@link Subscription} persistence.
+ */
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+}

--- a/src/main/java/moe/overnight/webstudy/repository/UserRepository.java
+++ b/src/main/java/moe/overnight/webstudy/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package moe.overnight.webstudy.repository;
+
+import moe.overnight.webstudy.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Spring Data repository providing CRUD operations for {@link User} entities.
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+    /**
+     * Derived query method that finds a user by username. Spring Data JPA parses
+     * the method name and generates the appropriate SQL automatically.
+     */
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/moe/overnight/webstudy/service/CommentService.java
+++ b/src/main/java/moe/overnight/webstudy/service/CommentService.java
@@ -1,0 +1,54 @@
+package moe.overnight.webstudy.service;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.comment.Comment;
+import moe.overnight.webstudy.domain.post.Post;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.repository.CommentRepository;
+import moe.overnight.webstudy.repository.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Service responsible for managing comments and replies.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    /**
+     * Adds a comment or reply to a post.
+     * @param postId   the id of the post being commented on
+     * @param parentId optional parent comment id for replies
+     */
+    public Comment addComment(Long postId, Long parentId, String content, User author) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        Comment.CommentBuilder builder = Comment.builder()
+                .post(post)
+                .author(author)
+                .content(content)
+                .createdAt(LocalDateTime.now());
+        if (parentId != null) {
+            Comment parent = commentRepository.findById(parentId)
+                    .orElseThrow(() -> new IllegalArgumentException("Parent comment not found"));
+            builder.parent(parent);
+        }
+        return commentRepository.save(builder.build());
+    }
+
+    /**
+     * Lists comments for a post.
+     */
+    public List<Comment> listByPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        return commentRepository.findByPost(post);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/service/NotificationService.java
+++ b/src/main/java/moe/overnight/webstudy/service/NotificationService.java
@@ -1,0 +1,50 @@
+package moe.overnight.webstudy.service;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.notification.Notification;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Service responsible for creating and retrieving notifications.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    /**
+     * Creates a notification for a given user.
+     */
+    public Notification notify(User user, String message) {
+        Notification notification = Notification.builder()
+                .user(user)
+                .message(message)
+                .read(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+        return notificationRepository.save(notification);
+    }
+
+    /**
+     * Lists all notifications for a user.
+     */
+    public List<Notification> list(User user) {
+        return notificationRepository.findByUser(user);
+    }
+
+    /**
+     * Marks the notification as read.
+     */
+    public void markRead(Long notificationId) {
+        notificationRepository.findById(notificationId).ifPresent(n -> {
+            n.setRead(true);
+        });
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/service/PostService.java
+++ b/src/main/java/moe/overnight/webstudy/service/PostService.java
@@ -1,0 +1,50 @@
+package moe.overnight.webstudy.service;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.category.Category;
+import moe.overnight.webstudy.domain.post.Post;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.repository.CategoryRepository;
+import moe.overnight.webstudy.repository.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Service layer for managing posts. The service encapsulates business
+ * logic and uses repositories to interact with the database.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostService {
+    private final PostRepository postRepository;
+    private final CategoryRepository categoryRepository;
+
+    /**
+     * Creates a new post within a given category.
+     */
+    public Post createPost(String title, String content, Long categoryId, User author) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+        Post post = Post.builder()
+                .title(title)
+                .content(content)
+                .category(category)
+                .author(author)
+                .createdAt(LocalDateTime.now())
+                .build();
+        return postRepository.save(post);
+    }
+
+    /**
+     * Returns all posts for a category.
+     */
+    public List<Post> listByCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+        return postRepository.findByCategory(category);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/service/SubscriptionService.java
+++ b/src/main/java/moe/overnight/webstudy/service/SubscriptionService.java
@@ -1,0 +1,35 @@
+package moe.overnight.webstudy.service;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.subscription.Subscription;
+import moe.overnight.webstudy.domain.subscription.SubscriptionPlan;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.repository.SubscriptionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * Service handling monthly subscription logic.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SubscriptionService {
+    private final SubscriptionRepository subscriptionRepository;
+
+    /**
+     * Subscribes a user to a given plan. In a real application payment handling
+     * would occur before activation.
+     */
+    public Subscription subscribe(User user, SubscriptionPlan plan) {
+        Subscription subscription = Subscription.builder()
+                .user(user)
+                .plan(plan)
+                .startDate(LocalDate.now())
+                .active(true)
+                .build();
+        return subscriptionRepository.save(subscription);
+    }
+}

--- a/src/main/java/moe/overnight/webstudy/service/UserService.java
+++ b/src/main/java/moe/overnight/webstudy/service/UserService.java
@@ -1,0 +1,59 @@
+package moe.overnight.webstudy.service;
+
+import lombok.RequiredArgsConstructor;
+import moe.overnight.webstudy.domain.user.User;
+import moe.overnight.webstudy.domain.user.UserRole;
+import moe.overnight.webstudy.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * Application service dealing with user registration and lookup. Annotated with
+ * {@link Service} to mark it as a Spring component and {@link Transactional}
+ * to ensure that database operations are executed within a transaction.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * Registers a new user. Password is encoded using the injected
+     * {@link PasswordEncoder} implementation (BCrypt by default).
+     */
+    public User register(String username, String password, String email) {
+        User user = User.builder()
+                .username(username)
+                .password(passwordEncoder.encode(password))
+                .email(email)
+                .role(UserRole.USER)
+                .build();
+        return userRepository.save(user);
+    }
+
+    /**
+     * Loads a user by username as required by the {@link UserDetailsService}
+     * contract used by Spring Security for authentication.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    /**
+     * Returns profile information for the given user id.
+     */
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=webstudy
+
+# Database configuration (PostgreSQL by default). Values should be adapted for the target environment.
+spring.datasource.url=jdbc:postgresql://localhost:5432/webstudy
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.hibernate.ddl-auto=update
+
+# Google OAuth2 configuration placeholders. Replace with real credentials.
+spring.security.oauth2.client.registration.google.client-id=google-client-id
+spring.security.oauth2.client.registration.google.client-secret=google-client-secret
+spring.security.oauth2.client.registration.google.scope=profile,email

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add user, post, comment, subscription and notification domain models
- implement basic services and REST controllers for registration, posts, comments, subscriptions and notifications
- configure Spring Security for form login and Google OAuth2 login with password encoding

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bc9c0a65e0832b996852ed694f5bb8